### PR TITLE
Handle incoming conns in their own goroutines

### DIFF
--- a/p2p/net/conn/dial_test.go
+++ b/p2p/net/conn/dial_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -464,6 +465,9 @@ func TestConcurrentAccept(t *testing.T) {
 
 	n := 300
 	delay := time.Millisecond * 20
+	if runtime.GOOS == "darwin" {
+		n = 100
+	}
 
 	p1.Addr = l1.Multiaddr() // Addr has been determined by kernel.
 

--- a/p2p/net/conn/listen.go
+++ b/p2p/net/conn/listen.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
+	"time"
 
 	ic "github.com/ipfs/go-libp2p/p2p/crypto"
 	filter "github.com/ipfs/go-libp2p/p2p/net/filter"
@@ -19,6 +21,26 @@ import (
 
 const SecioTag = "/secio/1.0.0"
 const NoEncryptionTag = "/plaintext/1.0.0"
+
+const connAcceptBuffer = 32
+const NegotiateReadTimeout = time.Second * 20
+
+var catcher = tec.TempErrCatcher{
+	IsTemp: func(e error) bool {
+		// ignore connection breakages up to this point. but log them
+		if e == io.EOF {
+			log.Debugf("listener ignoring conn with EOF: %s", e)
+			return true
+		}
+
+		te, ok := e.(tec.Temporary)
+		if ok {
+			log.Debugf("listener ignoring conn with temporary err: %s", e)
+			return te.Temporary()
+		}
+		return false
+	},
+}
 
 // ConnWrapper is any function that wraps a raw multiaddr connection
 type ConnWrapper func(transport.Conn) transport.Conn
@@ -37,6 +59,10 @@ type listener struct {
 	proc goprocess.Process
 
 	mux *msmux.MultistreamMuxer
+
+	incoming chan transport.Conn
+
+	ctx context.Context
 }
 
 func (l *listener) teardown() error {
@@ -60,57 +86,8 @@ func (l *listener) SetAddrFilters(fs *filter.Filters) {
 // Accept waits for and returns the next connection to the listener.
 // Note that unfortunately this
 func (l *listener) Accept() (net.Conn, error) {
-
-	// listeners dont have contexts. given changes dont make sense here anymore
-	// note that the parent of listener will Close, which will interrupt all io.
-	// Contexts and io don't mix.
-	ctx := context.Background()
-
-	var catcher tec.TempErrCatcher
-
-	catcher.IsTemp = func(e error) bool {
-		// ignore connection breakages up to this point. but log them
-		if e == io.EOF {
-			log.Debugf("listener ignoring conn with EOF: %s", e)
-			return true
-		}
-
-		te, ok := e.(tec.Temporary)
-		if ok {
-			log.Debugf("listener ignoring conn with temporary err: %s", e)
-			return te.Temporary()
-		}
-		return false
-	}
-
-	for {
-		maconn, err := l.Listener.Accept()
-		if err != nil {
-			if catcher.IsTemporary(err) {
-				continue
-			}
-			return nil, err
-		}
-
-		log.Debugf("listener %s got connection: %s <---> %s", l, maconn.LocalMultiaddr(), maconn.RemoteMultiaddr())
-
-		if l.filters != nil && l.filters.AddrBlocked(maconn.RemoteMultiaddr()) {
-			log.Debugf("blocked connection from %s", maconn.RemoteMultiaddr())
-			maconn.Close()
-			continue
-		}
-		// If we have a wrapper func, wrap this conn
-		if l.wrapper != nil {
-			maconn = l.wrapper(maconn)
-		}
-
-		_, _, err = l.mux.Negotiate(maconn)
-		if err != nil {
-			log.Info("negotiation of crypto protocol failed: ", err)
-			continue
-		}
-
-		c, err := newSingleConn(ctx, l.local, "", maconn)
+	for con := range l.incoming {
+		c, err := newSingleConn(l.ctx, l.local, "", con)
 		if err != nil {
 			if catcher.IsTemporary(err) {
 				continue
@@ -122,13 +99,14 @@ func (l *listener) Accept() (net.Conn, error) {
 			log.Warning("listener %s listening INSECURELY!", l)
 			return c, nil
 		}
-		sc, err := newSecureConn(ctx, l.privk, c)
+		sc, err := newSecureConn(l.ctx, l.privk, c)
 		if err != nil {
 			log.Infof("ignoring conn we failed to secure: %s %s", err, c)
 			continue
 		}
 		return sc, nil
 	}
+	return nil, fmt.Errorf("listener is closed")
 }
 
 func (l *listener) Addr() net.Addr {
@@ -157,12 +135,62 @@ func (l *listener) Loggable() map[string]interface{} {
 	}
 }
 
+func (l *listener) handleIncoming() {
+	var wg sync.WaitGroup
+	defer func() {
+		wg.Wait()
+		close(l.incoming)
+	}()
+
+	for {
+		maconn, err := l.Listener.Accept()
+		if err != nil {
+			if catcher.IsTemporary(err) {
+				continue
+			}
+			log.Warningf("listener errored and will close: %s", err)
+			return
+		}
+
+		log.Debugf("listener %s got connection: %s <---> %s", l, maconn.LocalMultiaddr(), maconn.RemoteMultiaddr())
+
+		if l.filters != nil && l.filters.AddrBlocked(maconn.RemoteMultiaddr()) {
+			log.Debugf("blocked connection from %s", maconn.RemoteMultiaddr())
+			maconn.Close()
+			continue
+		}
+		// If we have a wrapper func, wrap this conn
+		if l.wrapper != nil {
+			maconn = l.wrapper(maconn)
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			maconn.SetReadDeadline(time.Now().Add(NegotiateReadTimeout))
+			_, _, err = l.mux.Negotiate(maconn)
+			if err != nil {
+				log.Info("negotiation of crypto protocol failed: ", err)
+				maconn.Close()
+				return
+			}
+
+			// clear read readline
+			maconn.SetReadDeadline(time.Time{})
+
+			l.incoming <- maconn
+		}()
+	}
+}
+
 func WrapTransportListener(ctx context.Context, ml transport.Listener, local peer.ID, sk ic.PrivKey) (Listener, error) {
 	l := &listener{
 		Listener: ml,
 		local:    local,
 		privk:    sk,
 		mux:      msmux.NewMultistreamMuxer(),
+		incoming: make(chan transport.Conn, connAcceptBuffer),
+		ctx:      ctx,
 	}
 	l.proc = goprocessctx.WithContextAndTeardown(ctx, l.teardown)
 
@@ -171,6 +199,8 @@ func WrapTransportListener(ctx context.Context, ml transport.Listener, local pee
 	} else {
 		l.mux.AddHandler(NoEncryptionTag, nil)
 	}
+
+	go l.handleIncoming()
 
 	log.Debugf("Conn Listener on %s", l.Multiaddr())
 	log.Event(ctx, "swarmListen", l)

--- a/p2p/net/conn/listen.go
+++ b/p2p/net/conn/listen.go
@@ -19,11 +19,15 @@ import (
 	ma "gx/ipfs/QmcobAGsCjYt5DXoq9et9L8yR8er7o7Cu3DTvpaq12jYSz/go-multiaddr"
 )
 
-const SecioTag = "/secio/1.0.0"
-const NoEncryptionTag = "/plaintext/1.0.0"
+const (
+	SecioTag        = "/secio/1.0.0"
+	NoEncryptionTag = "/plaintext/1.0.0"
+)
 
-const connAcceptBuffer = 32
-const NegotiateReadTimeout = time.Second * 20
+var (
+	connAcceptBuffer     = 32
+	NegotiateReadTimeout = time.Second * 60
+)
 
 // ConnWrapper is any function that wraps a raw multiaddr connection
 type ConnWrapper func(transport.Conn) transport.Conn

--- a/package.json
+++ b/package.json
@@ -1,145 +1,153 @@
 {
-  "name": "go-libp2p",
   "author": "whyrusleeping",
-  "version": "1.0.0",
+  "bugs": {},
+  "gx": {
+    "dvcsimport": "github.com/ipfs/go-libp2p"
+  },
   "gxDependencies": [
     {
-      "name": "go-semver",
       "hash": "QmcrrEpx3VMUbrbgVroH3YiYyUS5c4YAykzyPJWKspUYLa",
+      "name": "go-semver",
       "version": "0.0.0"
     },
     {
-      "name": "mdns",
       "hash": "QmSscYPCcE1H3UQr2tnsJ2a9dK9LsHTBGgP71VW6fz67e5",
+      "name": "mdns",
       "version": "0.0.0"
     },
     {
-      "name": "go-msgio",
       "hash": "QmRQhVisS8dmPbjBUthVkenn81pBxrx1GxE281csJhm2vL",
+      "name": "go-msgio",
       "version": "0.0.0"
     },
     {
-      "name": "go-ipfs-util",
       "hash": "QmZNVWh8LLjAavuQ2JXuFmuYH3C11xo988vSgp7UQrTRj1",
+      "name": "go-ipfs-util",
       "version": "1.0.0"
     },
     {
-      "name": "go-keyspace",
       "hash": "QmUusaX99BZoELh7dmPgirqRQ1FAmMnmnBn3oiqDFGBUSc",
+      "name": "go-keyspace",
       "version": "1.0.0"
     },
     {
-      "name": "go-multistream",
       "hash": "QmUeEcYJrzAEKdQXjzTxCgNZgc9sRuwharsvzzm5Gd2oGB",
+      "name": "go-multistream",
       "version": "0.0.0"
     },
     {
-      "name": "go-nat",
       "hash": "QmNLvkCDV6ZjUJsEwGNporYBuZdhWT6q7TBVYQwwRv12HT",
+      "name": "go-nat",
       "version": "0.0.0"
     },
     {
-      "name": "go-detect-race",
       "hash": "QmQHGMVmrsgmqUG8ih3puNXUJneSpi13dkcZpzLKkskUkH",
+      "name": "go-detect-race",
       "version": "0.0.0"
     },
     {
-      "name": "goprocess",
       "hash": "QmQopLATEYMNg7dVqZRNDfeE2S1yKy8zrRh5xnYiuqeZBn",
+      "name": "goprocess",
       "version": "0.0.0"
     },
     {
-      "name": "go-log",
       "hash": "Qmazh5oNUVsDZTs2g59rq8aYQqwpss8tcUWQzor5sCCEuH",
+      "name": "go-log",
       "version": "0.0.0"
     },
     {
-      "name": "go-multiaddr-net",
       "hash": "QmYVqhVfbK4BKvbW88Lhm26b3ud14sTBvcm1H7uWUx1Fkp",
+      "name": "go-multiaddr-net",
       "version": "0.0.0"
     },
     {
-      "name": "go-multihash",
       "hash": "QmYf7ng2hG5XBtJA3tN34DQ2GUN5HNksEw1rLDkmr6vGku",
+      "name": "go-multihash",
       "version": "0.0.0"
     },
     {
-      "name": "multiaddr-filter",
       "hash": "QmPwfFAHUmvWDucLHRS9Xz2Kb1TNX2cY4LJ7pQjg9kVcae",
+      "name": "multiaddr-filter",
       "version": "1.0.0"
     },
     {
-      "name": "go-base58",
       "hash": "QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf",
+      "name": "go-base58",
       "version": "0.0.0"
     },
     {
-      "name": "go-crypto",
       "hash": "Qme1boxspcQWR8FBzMxeppqug2fYgYc15diNWmqgDVnvn2",
+      "name": "go-crypto",
       "version": "0.0.0"
     },
     {
-      "name": "gogo-protobuf",
       "hash": "QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV",
+      "name": "gogo-protobuf",
       "version": "0.0.0"
     },
     {
-      "name": "go-multiaddr",
       "hash": "QmcobAGsCjYt5DXoq9et9L8yR8er7o7Cu3DTvpaq12jYSz",
+      "name": "go-multiaddr",
       "version": "0.0.0"
     },
     {
-      "name": "go-metrics",
       "hash": "QmeYJHEk8UjVVZ4XCRTZe6dFQrb8pGWD81LYCgeLp8CvMB",
+      "name": "go-metrics",
       "version": "0.0.0"
     },
     {
-      "name": "randbo",
       "hash": "QmYvsG72GsfLgUeSojXArjnU6L4Wmwk7wuAxtNLuyXcc1T",
+      "name": "randbo",
       "version": "0.0.0"
     },
     {
-      "name": "go-net",
       "hash": "QmZy2y8t9zQH2a1b8q2ZSLKp17ATuJoCNxxyMFG5qFExpt",
+      "name": "go-net",
       "version": "0.0.0"
     },
     {
-      "name": "go-stream-muxer",
       "hash": "QmWSJzRkCMJFHYUQZxKwPX8WA7XipaPtfiwMPARP51ymfn",
+      "name": "go-stream-muxer",
       "version": "0.0.0"
     },
     {
-      "name": "go-reuseport",
       "hash": "QmaaC9QMYTQHCbMq3Ebr3uMaAR2ev4AVqMmsJpgQijAZbJ",
+      "name": "go-reuseport",
       "version": "0.0.0"
     },
     {
-      "name": "go-notifier",
       "hash": "QmbcS9XrwZkF1rZj8bBwwzoYhVuA2PCnPhFUL1pyWGgt2A",
+      "name": "go-notifier",
       "version": "0.0.0"
     },
     {
-      "name": "go-temp-err-catcher",
       "hash": "QmWHgLqrghM9zw77nF6gdvT9ExQ2RB9pLxkd8sDHZf1rWb",
+      "name": "go-temp-err-catcher",
       "version": "0.0.0"
     },
     {
-      "name": "go-peerstream",
       "hash": "QmZK81vcgMhpb2t7GNbozk7qzt6Rj4zFqitpvsWT9mduW8",
+      "name": "go-peerstream",
       "version": "0.0.0"
     },
     {
       "author": "whyrusleeping",
-      "name": "mafmt",
       "hash": "QmWLfU4tstw2aNcTykDm44xbSTCYJ9pUJwfhQCKGwckcHx",
+      "name": "mafmt",
+      "version": "0.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmTd4Jgb4nbJq5uR55KJgGLyHWmM3dovS21D1HcwRneSLu",
+      "name": "gorocheck",
       "version": "0.0.0"
     }
   ],
+  "gxVersion": "0.4.0",
+  "gx_version": "0.4.0",
+  "issues_url": "",
   "language": "go",
   "license": "",
-  "bugs": "",
-  "gxVersion": "0.4.0",
-  "gx": {
-    "dvcsimport": "github.com/ipfs/go-libp2p"
-  }
+  "name": "go-libp2p",
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Doing the multistream negotiation in sync causes hanging issues.
This commit accepts transport connections and starts the negotiation
in a separate goroutine, sending it down a channel when its ready.