### PR TITLE
gx publish version 3.2.1

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.2.0: QmZpVD1kkRwoC67vNknvCrY72pjmVdtZ7txSk8mtCbuwd3
+3.2.1: QmUHrgorZ1F9yGkgF2His5fsQ9xtCzjdsPGjizmcEW94i5

--- a/package.json
+++ b/package.json
@@ -186,5 +186,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-libp2p",
-  "version": "3.2.0"
+  "version": "3.2.1"
 }


### PR DESCRIPTION
contains:
 - ID service hang fix #49 
 - Yamux stream hang patches #50 