### PR TITLE
update to official yamux fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,9 +165,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSHTSkxXGQgaHWz91oZV3CDy3hmKmDgpjbYRT6niACG4E",
+      "hash": "QmRgddEN3nMY2jecG3EFNTMZzdk1gXEnPQxksJuReMTUZV",
       "name": "go-smux-yamux",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
https://github.com/hashicorp/yamux/pull/28 and https://github.com/hashicorp/yamux/pull/29 were merged, this updates libp2p to use the official code as opposed to the hacked together fix i pushed earlier