### PR TITLE
split peerstore from peer package

### DIFF
--- a/p2p/discovery/mdns.go
+++ b/p2p/discovery/mdns.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cryptix/mdns"
 	"github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	"github.com/ipfs/go-libp2p/p2p/host"
 	logging "github.com/ipfs/go-log"
 	ma "github.com/jbenet/go-multiaddr"
@@ -28,7 +29,7 @@ type Service interface {
 }
 
 type Notifee interface {
-	HandlePeerFound(peer.PeerInfo)
+	HandlePeerFound(pstore.PeerInfo)
 }
 
 type mdnsService struct {
@@ -154,7 +155,7 @@ func (m *mdnsService) handleEntry(e *mdns.ServiceEntry) {
 		return
 	}
 
-	pi := peer.PeerInfo{
+	pi := pstore.PeerInfo{
 		ID:    mpeer,
 		Addrs: []ma.Multiaddr{maddr},
 	}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	mstream "github.com/ipfs/go-libp2p/p2p/metrics/stream"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
@@ -122,7 +123,7 @@ func (h *BasicHost) ID() peer.ID {
 }
 
 // Peerstore returns the Host's repository of Peer Addresses and Keys.
-func (h *BasicHost) Peerstore() peer.Peerstore {
+func (h *BasicHost) Peerstore() pstore.Peerstore {
 	return h.Network().Peerstore()
 }
 
@@ -181,10 +182,10 @@ func (h *BasicHost) NewStream(ctx context.Context, pid protocol.ID, p peer.ID) (
 // peerstore. If there is not an active connection, Connect will issue a
 // h.Network.Dial, and block until a connection is open, or an error is
 // returned. // TODO: Relay + NAT.
-func (h *BasicHost) Connect(ctx context.Context, pi peer.PeerInfo) error {
+func (h *BasicHost) Connect(ctx context.Context, pi pstore.PeerInfo) error {
 
 	// absorb addresses into peerstore
-	h.Peerstore().AddAddrs(pi.ID, pi.Addrs, peer.TempAddrTTL)
+	h.Peerstore().AddAddrs(pi.ID, pi.Addrs, pstore.TempAddrTTL)
 
 	cs := h.Network().ConnsToPeer(pi.ID)
 	if len(cs) > 0 {

--- a/p2p/host/host.go
+++ b/p2p/host/host.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
 	protocol "github.com/ipfs/go-libp2p/p2p/protocol"
@@ -23,7 +24,7 @@ type Host interface {
 	ID() peer.ID
 
 	// Peerstore returns the Host's repository of Peer Addresses and Keys.
-	Peerstore() peer.Peerstore
+	Peerstore() pstore.Peerstore
 
 	// Returns the listen addresses of the Host
 	Addrs() []ma.Multiaddr
@@ -39,7 +40,7 @@ type Host interface {
 	// peerstore. If there is not an active connection, Connect will issue a
 	// h.Network.Dial, and block until a connection is open, or an error is
 	// returned. // TODO: Relay + NAT.
-	Connect(ctx context.Context, pi peer.PeerInfo) error
+	Connect(ctx context.Context, pi pstore.PeerInfo) error
 
 	// SetStreamHandler sets the protocol handler on the Host's Mux.
 	// This is equivalent to:

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -6,6 +6,7 @@ import (
 
 	lgbl "github.com/ipfs/go-libp2p-loggables"
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	host "github.com/ipfs/go-libp2p/p2p/host"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
@@ -32,7 +33,7 @@ type RoutedHost struct {
 }
 
 type Routing interface {
-	FindPeer(context.Context, peer.ID) (peer.PeerInfo, error)
+	FindPeer(context.Context, peer.ID) (pstore.PeerInfo, error)
 }
 
 func Wrap(h host.Host, r Routing) *RoutedHost {
@@ -44,7 +45,7 @@ func Wrap(h host.Host, r Routing) *RoutedHost {
 //
 // RoutedHost's Connect differs in that if the host has no addresses for a
 // given peer, it will use its routing system to try to find some.
-func (rh *RoutedHost) Connect(ctx context.Context, pi peer.PeerInfo) error {
+func (rh *RoutedHost) Connect(ctx context.Context, pi pstore.PeerInfo) error {
 	// first, check if we're already connected.
 	if len(rh.Network().ConnsToPeer(pi.ID)) > 0 {
 		return nil
@@ -52,7 +53,7 @@ func (rh *RoutedHost) Connect(ctx context.Context, pi peer.PeerInfo) error {
 
 	// if we were given some addresses, keep + use them.
 	if len(pi.Addrs) > 0 {
-		rh.Peerstore().AddAddrs(pi.ID, pi.Addrs, peer.TempAddrTTL)
+		rh.Peerstore().AddAddrs(pi.ID, pi.Addrs, pstore.TempAddrTTL)
 	}
 
 	// Check if we have some addresses in our recent memory.
@@ -89,7 +90,7 @@ func (rh *RoutedHost) ID() peer.ID {
 	return rh.host.ID()
 }
 
-func (rh *RoutedHost) Peerstore() peer.Peerstore {
+func (rh *RoutedHost) Peerstore() pstore.Peerstore {
 	return rh.host.Peerstore()
 }
 

--- a/p2p/net/interface.go
+++ b/p2p/net/interface.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	conn "github.com/ipfs/go-libp2p/p2p/net/conn"
 	ma "github.com/jbenet/go-multiaddr"
 	"github.com/jbenet/goprocess"
@@ -91,7 +92,7 @@ type Dialer interface {
 	// Peerstore returns the internal peerstore
 	// This is useful to tell the dialer about a new address for a peer.
 	// Or use one of the public keys found out over the network.
-	Peerstore() peer.Peerstore
+	Peerstore() pstore.Peerstore
 
 	// LocalPeer returns the local peer associated with this network
 	LocalPeer() peer.ID

--- a/p2p/net/mock/interface.go
+++ b/p2p/net/mock/interface.go
@@ -7,13 +7,15 @@
 package mocknet
 
 import (
-	ic "github.com/ipfs/go-libp2p-crypto"
-	peer "github.com/ipfs/go-libp2p-peer"
-	host "github.com/ipfs/go-libp2p/p2p/host"
-	inet "github.com/ipfs/go-libp2p/p2p/net"
 	"io"
 	"time"
 
+	host "github.com/ipfs/go-libp2p/p2p/host"
+	inet "github.com/ipfs/go-libp2p/p2p/net"
+
+	ic "github.com/ipfs/go-libp2p-crypto"
+	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 )
 
@@ -25,7 +27,7 @@ type Mocknet interface {
 	// AddPeer adds an existing peer. we need both a privkey and addr.
 	// ID is derived from PrivKey
 	AddPeer(ic.PrivKey, ma.Multiaddr) (host.Host, error)
-	AddPeerWithPeerstore(peer.ID, peer.Peerstore) (host.Host, error)
+	AddPeerWithPeerstore(peer.ID, pstore.Peerstore) (host.Host, error)
 
 	// retrieve things (with randomized iteration order)
 	Peers() []peer.ID

--- a/p2p/net/mock/mock_net.go
+++ b/p2p/net/mock/mock_net.go
@@ -5,14 +5,15 @@ import (
 	"sort"
 	"sync"
 
-	ic "github.com/ipfs/go-libp2p-crypto"
-	peer "github.com/ipfs/go-libp2p-peer"
 	host "github.com/ipfs/go-libp2p/p2p/host"
 	bhost "github.com/ipfs/go-libp2p/p2p/host/basic"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
 	p2putil "github.com/ipfs/go-libp2p/p2p/test/util"
 	testutil "github.com/ipfs/go-libp2p/testutil"
 
+	ic "github.com/ipfs/go-libp2p-crypto"
+	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 	"github.com/jbenet/goprocess"
 	goprocessctx "github.com/jbenet/goprocess/context"
@@ -69,15 +70,15 @@ func (mn *mocknet) AddPeer(k ic.PrivKey, a ma.Multiaddr) (host.Host, error) {
 		return nil, err
 	}
 
-	ps := peer.NewPeerstore()
-	ps.AddAddr(p, a, peer.PermanentAddrTTL)
+	ps := pstore.NewPeerstore()
+	ps.AddAddr(p, a, pstore.PermanentAddrTTL)
 	ps.AddPrivKey(p, k)
 	ps.AddPubKey(p, k.GetPublic())
 
 	return mn.AddPeerWithPeerstore(p, ps)
 }
 
-func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps peer.Peerstore) (host.Host, error) {
+func (mn *mocknet) AddPeerWithPeerstore(p peer.ID, ps pstore.Peerstore) (host.Host, error) {
 	n, err := newPeernet(mn.ctx, mn, p, ps)
 	if err != nil {
 		return nil, err

--- a/p2p/net/mock/mock_peernet.go
+++ b/p2p/net/mock/mock_peernet.go
@@ -5,8 +5,10 @@ import (
 	"math/rand"
 	"sync"
 
-	peer "github.com/ipfs/go-libp2p-peer"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
+
+	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 	"github.com/jbenet/goprocess"
 	goprocessctx "github.com/jbenet/goprocess/context"
@@ -18,7 +20,7 @@ type peernet struct {
 	mocknet *mocknet // parent
 
 	peer peer.ID
-	ps   peer.Peerstore
+	ps   pstore.Peerstore
 
 	// conns are actual live connections between peers.
 	// many conns could run over each link.
@@ -38,7 +40,7 @@ type peernet struct {
 }
 
 // newPeernet constructs a new peernet
-func newPeernet(ctx context.Context, m *mocknet, p peer.ID, ps peer.Peerstore) (*peernet, error) {
+func newPeernet(ctx context.Context, m *mocknet, p peer.ID, ps pstore.Peerstore) (*peernet, error) {
 
 	n := &peernet{
 		mocknet: m,
@@ -82,7 +84,7 @@ func (pn *peernet) Close() error {
 	return pn.proc.Close()
 }
 
-func (pn *peernet) Peerstore() peer.Peerstore {
+func (pn *peernet) Peerstore() pstore.Peerstore {
 	return pn.ps
 }
 
@@ -293,7 +295,7 @@ func (pn *peernet) BandwidthTotals() (in uint64, out uint64) {
 
 // Listen tells the network to start listening on given multiaddrs.
 func (pn *peernet) Listen(addrs ...ma.Multiaddr) error {
-	pn.Peerstore().AddAddrs(pn.LocalPeer(), addrs, peer.PermanentAddrTTL)
+	pn.Peerstore().AddAddrs(pn.LocalPeer(), addrs, pstore.PermanentAddrTTL)
 	return nil
 }
 

--- a/p2p/net/swarm/dial_test.go
+++ b/p2p/net/swarm/dial_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	peer "github.com/ipfs/go-libp2p-peer"
 	addrutil "github.com/ipfs/go-libp2p/p2p/net/swarm/addr"
 	testutil "github.com/ipfs/go-libp2p/testutil"
 	ci "github.com/ipfs/go-libp2p/testutil/ci"
 
+	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 	manet "github.com/jbenet/go-multiaddr-net"
 	context "golang.org/x/net/context"
@@ -32,7 +33,7 @@ func TestBasicDial(t *testing.T) {
 	s1 := swarms[0]
 	s2 := swarms[1]
 
-	s1.peers.AddAddrs(s2.local, s2.ListenAddresses(), peer.PermanentAddrTTL)
+	s1.peers.AddAddrs(s2.local, s2.ListenAddresses(), pstore.PermanentAddrTTL)
 
 	c, err := s1.Dial(ctx, s2.local)
 	if err != nil {
@@ -57,7 +58,7 @@ func TestDialWithNoListeners(t *testing.T) {
 	defer closeSwarms(swarms)
 	s2 := swarms[0]
 
-	s1.peers.AddAddrs(s2.local, s2.ListenAddresses(), peer.PermanentAddrTTL)
+	s1.peers.AddAddrs(s2.local, s2.ListenAddresses(), pstore.PermanentAddrTTL)
 
 	c, err := s1.Dial(ctx, s2.local)
 	if err != nil {
@@ -101,7 +102,7 @@ func TestSimultDials(t *testing.T) {
 		connect := func(s *Swarm, dst peer.ID, addr ma.Multiaddr) {
 			// copy for other peer
 			log.Debugf("TestSimultOpen: connecting: %s --> %s (%s)", s.local, dst, addr)
-			s.peers.AddAddr(dst, addr, peer.TempAddrTTL)
+			s.peers.AddAddr(dst, addr, pstore.TempAddrTTL)
 			if _, err := s.Dial(ctx, dst); err != nil {
 				t.Fatal("error swarm dialing to peer", err)
 			}
@@ -178,7 +179,7 @@ func TestDialWait(t *testing.T) {
 	s2p, s2addr, s2l := newSilentPeer(t)
 	go acceptAndHang(s2l)
 	defer s2l.Close()
-	s1.peers.AddAddr(s2p, s2addr, peer.PermanentAddrTTL)
+	s1.peers.AddAddr(s2p, s2addr, pstore.PermanentAddrTTL)
 
 	before := time.Now()
 	if c, err := s1.Dial(ctx, s2p); err == nil {
@@ -224,13 +225,13 @@ func TestDialBackoff(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s1.peers.AddAddrs(s2.local, s2addrs, peer.PermanentAddrTTL)
+	s1.peers.AddAddrs(s2.local, s2addrs, pstore.PermanentAddrTTL)
 
 	// dial to a non-existent peer.
 	s3p, s3addr, s3l := newSilentPeer(t)
 	go acceptAndHang(s3l)
 	defer s3l.Close()
-	s1.peers.AddAddr(s3p, s3addr, peer.PermanentAddrTTL)
+	s1.peers.AddAddr(s3p, s3addr, pstore.PermanentAddrTTL)
 
 	// in this test we will:
 	//   1) dial 10x to each node.
@@ -442,7 +443,7 @@ func TestDialBackoffClears(t *testing.T) {
 	defer s2l.Close()
 
 	// phase 1 -- dial to non-operational addresses
-	s1.peers.AddAddr(s2.local, s2bad, peer.PermanentAddrTTL)
+	s1.peers.AddAddr(s2.local, s2bad, pstore.PermanentAddrTTL)
 
 	before := time.Now()
 	if c, err := s1.Dial(ctx, s2.local); err == nil {
@@ -472,7 +473,7 @@ func TestDialBackoffClears(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s1.peers.AddAddrs(s2.local, ifaceAddrs1, peer.PermanentAddrTTL)
+	s1.peers.AddAddrs(s2.local, ifaceAddrs1, pstore.PermanentAddrTTL)
 
 	if _, err := s1.Dial(ctx, s2.local); err == nil {
 		t.Fatal("should have failed to dial backed off peer")

--- a/p2p/net/swarm/peers_test.go
+++ b/p2p/net/swarm/peers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 	context "golang.org/x/net/context"
 )
@@ -17,7 +18,7 @@ func TestPeers(t *testing.T) {
 
 	connect := func(s *Swarm, dst peer.ID, addr ma.Multiaddr) {
 		// TODO: make a DialAddr func.
-		s.peers.AddAddr(dst, addr, peer.PermanentAddrTTL)
+		s.peers.AddAddr(dst, addr, pstore.PermanentAddrTTL)
 		// t.Logf("connections from %s", s.LocalPeer())
 		// for _, c := range s.ConnectionsToPeer(dst) {
 		// 	t.Logf("connection from %s to %s: %v", s.LocalPeer(), dst, c)

--- a/p2p/net/swarm/simul_test.go
+++ b/p2p/net/swarm/simul_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	peer "github.com/ipfs/go-libp2p-peer"
 	ci "github.com/ipfs/go-libp2p/testutil/ci"
 
+	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 	context "golang.org/x/net/context"
 )
@@ -26,7 +27,7 @@ func TestSimultOpen(t *testing.T) {
 		connect := func(s *Swarm, dst peer.ID, addr ma.Multiaddr) {
 			// copy for other peer
 			log.Debugf("TestSimultOpen: connecting: %s --> %s (%s)", s.local, dst, addr)
-			s.peers.AddAddr(dst, addr, peer.PermanentAddrTTL)
+			s.peers.AddAddr(dst, addr, pstore.PermanentAddrTTL)
 			if _, err := s.Dial(ctx, dst); err != nil {
 				t.Fatal("error swarm dialing to peer", err)
 			}

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	transport "github.com/ipfs/go-libp2p-transport"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	mconn "github.com/ipfs/go-libp2p/p2p/metrics/conn"
@@ -67,7 +68,7 @@ func init() {
 type Swarm struct {
 	swarm *ps.Swarm
 	local peer.ID
-	peers peer.Peerstore
+	peers pstore.Peerstore
 	connh ConnHandler
 
 	dsync dialsync
@@ -94,7 +95,7 @@ type Swarm struct {
 
 // NewSwarm constructs a Swarm, with a Chan.
 func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
-	local peer.ID, peers peer.Peerstore, bwc metrics.Reporter) (*Swarm, error) {
+	local peer.ID, peers pstore.Peerstore, bwc metrics.Reporter) (*Swarm, error) {
 
 	listenAddrs, err := filterAddrs(listenAddrs)
 	if err != nil {

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -3,11 +3,11 @@ package swarm
 import (
 	"testing"
 
-	peer "github.com/ipfs/go-libp2p-peer"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	addrutil "github.com/ipfs/go-libp2p/p2p/net/swarm/addr"
 	testutil "github.com/ipfs/go-libp2p/testutil"
 
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 	context "golang.org/x/net/context"
 )
@@ -63,7 +63,7 @@ func TestFilterAddrs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ps := peer.NewPeerstore()
+	ps := pstore.NewPeerstore()
 	ctx := context.Background()
 
 	if _, err := NewNetwork(ctx, bad, id, ps, metrics.NewBandwidthCounter()); err == nil {
@@ -111,7 +111,7 @@ func TestDialBadAddrs(t *testing.T) {
 
 	test := func(a ma.Multiaddr) {
 		p := testutil.RandPeerIDFatal(t)
-		s.peers.AddAddr(p, a, peer.PermanentAddrTTL)
+		s.peers.AddAddr(p, a, pstore.PermanentAddrTTL)
 		if _, err := s.Dial(ctx, p); err == nil {
 			t.Error("swarm should not dial: %s", m)
 		}

--- a/p2p/net/swarm/swarm_net.go
+++ b/p2p/net/swarm/swarm_net.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
 
@@ -19,7 +20,7 @@ type Network Swarm
 
 // NewNetwork constructs a new network and starts listening on given addresses.
 func NewNetwork(ctx context.Context, listen []ma.Multiaddr, local peer.ID,
-	peers peer.Peerstore, bwc metrics.Reporter) (*Network, error) {
+	peers pstore.Peerstore, bwc metrics.Reporter) (*Network, error) {
 
 	s, err := NewSwarm(ctx, listen, local, peers, bwc)
 	if err != nil {
@@ -63,7 +64,7 @@ func (n *Network) Peers() []peer.ID {
 }
 
 // Peers returns the Peerstore, which tracks known peers
-func (n *Network) Peerstore() peer.Peerstore {
+func (n *Network) Peerstore() pstore.Peerstore {
 	return n.Swarm().peers
 }
 

--- a/p2p/protocol/identify/id.go
+++ b/p2p/protocol/identify/id.go
@@ -6,7 +6,7 @@ import (
 
 	semver "github.com/coreos/go-semver/semver"
 	ggio "github.com/gogo/protobuf/io"
-	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	host "github.com/ipfs/go-libp2p/p2p/host"
 	mstream "github.com/ipfs/go-libp2p/p2p/metrics/stream"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
@@ -194,7 +194,7 @@ func (ids *IDService) consumeMessage(mes *pb.Identify, c inet.Conn) {
 
 	// update our peerstore with the addresses. here, we SET the addresses, clearing old ones.
 	// We are receiving from the peer itself. this is current address ground truth.
-	ids.Host.Peerstore().SetAddrs(p, lmaddrs, peer.ConnectedAddrTTL)
+	ids.Host.Peerstore().SetAddrs(p, lmaddrs, pstore.ConnectedAddrTTL)
 	log.Debugf("%s received listen addrs for %s: %s", c.LocalPeer(), c.RemotePeer(), lmaddrs)
 
 	// get protocol versions
@@ -317,7 +317,7 @@ func (nn *netNotifiee) Disconnected(n inet.Network, v inet.Conn) {
 	ids := nn.IDService()
 	ps := ids.Host.Peerstore()
 	addrs := ps.Addrs(v.RemotePeer())
-	ps.SetAddrs(v.RemotePeer(), addrs, peer.RecentlyConnectedAddrTTL)
+	ps.SetAddrs(v.RemotePeer(), addrs, pstore.RecentlyConnectedAddrTTL)
 }
 
 func (nn *netNotifiee) OpenedStream(n inet.Network, v inet.Stream) {}

--- a/p2p/protocol/identify/obsaddr.go
+++ b/p2p/protocol/identify/obsaddr.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	ma "github.com/jbenet/go-multiaddr"
 )
 
@@ -69,7 +69,7 @@ func (oas *ObservedAddrSet) Add(addr ma.Multiaddr, observer ma.Multiaddr) {
 	// for zero-value.
 	if oas.addrs == nil {
 		oas.addrs = make(map[string]*ObservedAddr)
-		oas.ttl = peer.OwnObservedAddrTTL
+		oas.ttl = pstore.OwnObservedAddrTTL
 	}
 
 	s := addr.String()
@@ -114,7 +114,7 @@ func (oas *ObservedAddrSet) TTL() time.Duration {
 	defer oas.Unlock()
 	// for zero-value.
 	if oas.addrs == nil {
-		oas.ttl = peer.OwnObservedAddrTTL
+		oas.ttl = pstore.OwnObservedAddrTTL
 	}
 	return oas.ttl
 }

--- a/p2p/protocol/ping/ping_test.go
+++ b/p2p/protocol/ping/ping_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 	"time"
 
-	peer "github.com/ipfs/go-libp2p-peer"
 	netutil "github.com/ipfs/go-libp2p/p2p/test/util"
+
+	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	context "golang.org/x/net/context"
 )
 
@@ -15,7 +17,7 @@ func TestPing(t *testing.T) {
 	h1 := netutil.GenHostSwarm(t, ctx)
 	h2 := netutil.GenHostSwarm(t, ctx)
 
-	err := h1.Connect(ctx, peer.PeerInfo{
+	err := h1.Connect(ctx, pstore.PeerInfo{
 		ID:    h2.ID(),
 		Addrs: h2.Addrs(),
 	})

--- a/p2p/test/util/util.go
+++ b/p2p/test/util/util.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"testing"
 
-	peer "github.com/ipfs/go-libp2p-peer"
+	pstore "github.com/ipfs/go-libp2p-peerstore"
 	bhost "github.com/ipfs/go-libp2p/p2p/host/basic"
 	metrics "github.com/ipfs/go-libp2p/p2p/metrics"
 	inet "github.com/ipfs/go-libp2p/p2p/net"
@@ -16,21 +16,21 @@ import (
 
 func GenSwarmNetwork(t *testing.T, ctx context.Context) *swarm.Network {
 	p := tu.RandPeerNetParamsOrFatal(t)
-	ps := peer.NewPeerstore()
+	ps := pstore.NewPeerstore()
 	ps.AddPubKey(p.ID, p.PubKey)
 	ps.AddPrivKey(p.ID, p.PrivKey)
 	n, err := swarm.NewNetwork(ctx, []ma.Multiaddr{p.Addr}, p.ID, ps, metrics.NewBandwidthCounter())
 	if err != nil {
 		t.Fatal(err)
 	}
-	ps.AddAddrs(p.ID, n.ListenAddresses(), peer.PermanentAddrTTL)
+	ps.AddAddrs(p.ID, n.ListenAddresses(), pstore.PermanentAddrTTL)
 	return n
 }
 
 func DivulgeAddresses(a, b inet.Network) {
 	id := a.LocalPeer()
 	addrs := a.Peerstore().Addrs(id)
-	b.Peerstore().AddAddrs(id, addrs, peer.PermanentAddrTTL)
+	b.Peerstore().AddAddrs(id, addrs, pstore.PermanentAddrTTL)
 }
 
 func GenHostSwarm(t *testing.T, ctx context.Context) *bhost.BasicHost {

--- a/package.json
+++ b/package.json
@@ -147,21 +147,21 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmTfX8ffnQZ4twPpfC9ye7FcFeFKw4najRESmyeymsT6aa",
+      "hash": "QmUTWSWuaYmFdfb5UMmLxBdk9SrQUbyArrVvw6uRx2rLCU",
       "name": "go-libp2p-loggables",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbuSYB51KtX8izgab1fSyBgsyMH2hTuCfBtXm77PeXWca",
+      "hash": "QmUmvxT1NTXjk4v9ucPHgC5NHd7s2nHXrVvFbs68NrGuZC",
       "name": "go-libp2p-secio",
-      "version": "1.0.4"
+      "version": "1.0.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmboVACz6WES3byh3q8jdYPWL9TMz7CT89V34WPtruuRoS",
+      "hash": "QmQ6qQtDoFjfNoXoR74sxYWggGAFzeLxf4JCa2ATpbvvCp",
       "name": "go-libp2p-transport",
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     {
       "author": "whyrusleeping",
@@ -179,6 +179,12 @@
       "author": "whyrusleeping",
       "hash": "QmWMKNLGkYJTZ4Tq3DQ8E9j86QaKvGjKgFzvLzGYXvW69Z",
       "name": "go-smux-spdystream",
+      "version": "1.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmZ62t46e9p7vMYqCmptwQC1RhRv5cpQ5cwoqYspedaXyq",
+      "name": "go-libp2p-peerstore",
       "version": "1.0.0"
     }
   ],


### PR DESCRIPTION
This will make updates to the peerstore cause much less churn on the dependency tree.